### PR TITLE
Filtering retweets and separated logic to parse tweets in a service

### DIFF
--- a/app/services/tweet_parser_service.rb
+++ b/app/services/tweet_parser_service.rb
@@ -1,0 +1,27 @@
+class TweetParserService
+  attr_reader :tweet, :text, :user, :id, :hashtags
+
+  def initialize(tweet)
+    @tweet = tweet
+    @id = tweet[:id]
+    @user = tweet[:user]
+    @text = parse_tweet_text
+    @hashtags = parse_tweet_hashtags
+  end
+
+  def parse_tweet_text
+    if @tweet[:truncated] 
+      return @tweet[:extended_tweet][:full_text]
+    end
+    return @tweet[:text]
+  end
+
+  def parse_tweet_hashtags
+    if @tweet[:truncated] 
+      hashtags = @tweet[:extended_tweet][:entities][:hashtags]
+    else
+      hashtags = @tweet[:entities][:hashtags]
+    end
+    return hashtags.map {|h| {text: h[:text].downcase}}
+  end
+end

--- a/test/services/twitter_stream_test.rb
+++ b/test/services/twitter_stream_test.rb
@@ -53,15 +53,4 @@ class  TwitterStreamServiceTest < ActiveSupport::TestCase
     assert_equal Hashtag.count, count + 1
     assert_equal hashtag, Hashtag.find_by(text: 'argentina')
   end
-
-  test "it creates tweet" do
-    count = Tweet.count
-    user = User.first
-    text = 'test tweet'
-    id = 123
-    tweet = TwitterStreamService.instance.createTweet(text, user, id)
-    assert_equal Tweet.count, count + 1
-    assert_equal tweet.user, user
-    assert_equal tweet.text, text
-  end
 end


### PR DESCRIPTION
Closes #2

Filtering retweets with the API needs an enterprise package (non-free) using the [premium operator](https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/premium-operators) is:retweet. But we can still detect a retweet by checking the presence of the retweeted_status in the tweet object, when found we will just skip it.

Separated the logic to parse tweets in a service TweetParserService to isolate that logic.